### PR TITLE
Optimize token usage and reduce logs

### DIFF
--- a/src/controllers/IngredientController.js
+++ b/src/controllers/IngredientController.js
@@ -5,20 +5,11 @@ import LoginController from './LoginController';
 
 const baseUrl = 'http://149.50.131.253/api';
 
-const waitUntilTokenIsAvailable = async () => {
-  let token = LoginController.getToken();
-  while (!token) {
-      console.log('Esperando a que se obtenga un token de autenticación...');
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      token = LoginController.getToken();
-  }
-  return token;
-};
+const getToken = () => LoginController.getToken();
 
 export const fetchIngredientes = async () => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    const { ingredientes } = await sendAuthenticatedRequest(`${baseUrl}/ingredientes`, token);
+    const { ingredientes } = await sendAuthenticatedRequest(`${baseUrl}/ingredientes`);
     return ingredientes;
   } catch (error) {
     console.error('Error al obtener los ingredientes:', error.message);
@@ -28,8 +19,7 @@ export const fetchIngredientes = async () => {
 
 export const fetchIngredientesMenosStock = async () => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    const response = await sendAuthenticatedRequest(`${baseUrl}/ingredientes/menosstock`, token);
+    const response = await sendAuthenticatedRequest(`${baseUrl}/ingredientes/menosstock`);
     return response;
   } catch (error) {
     console.error('Error al obtener los ingredientes con menos stock:', error.message);
@@ -39,16 +29,13 @@ export const fetchIngredientesMenosStock = async () => {
 
 export const agregarIngrediente = async (ingrediente) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    console.log('Token utilizado para agregar el ingrediente:', token); // Agregar este console log
-    console.log('Datos del ingrediente a agregar:', ingrediente); // Agregar este console log
+    const token = getToken();
     const response = await axios.post(`${baseUrl}/ingredientes`, ingrediente, {
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
-      }
+        Authorization: `Bearer ${token}`,
+      },
     });
-    console.log('Respuesta del servidor al agregar ingrediente:', response); // Agregar este console log
     return response.data;
   } catch (error) {
     console.error('Error al agregar el ingrediente:', error);
@@ -58,16 +45,13 @@ export const agregarIngrediente = async (ingrediente) => {
 
 export const editarIngrediente = async (ingrediente) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    console.log('Token utilizado para editar el ingrediente:', token); // Agregar este console log
-    console.log('Datos del ingrediente a editar:', ingrediente); // Agregar este console log
+    const token = getToken();
     const response = await axios.put(`${baseUrl}/ingredientes/${ingrediente.id}`, ingrediente, {
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
-      }
+        Authorization: `Bearer ${token}`,
+      },
     });
-    console.log('Respuesta del servidor al editar ingrediente:', response); // Agregar este console log
     return response.data;
   } catch (error) {
     console.error('Error al editar el ingrediente:', error);
@@ -77,17 +61,14 @@ export const editarIngrediente = async (ingrediente) => {
 
 export const borrarIngrediente = async (id) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    console.log('Token utilizado para borrar el ingrediente:', token); // Agregar este console log
-    console.log('ID del ingrediente a borrar:', id); // Agregar este console log
+    const token = getToken();
     const response = await axios.delete(`${baseUrl}/ingredientes/${id}`, {
       headers: {
-        'Authorization': `Bearer ${token}`,
-      }
+        Authorization: `Bearer ${token}`,
+      },
     });
 
     if (response.status === 200) {
-      console.log('Ingrediente eliminado exitosamente');
       return { success: true };
     } else {
       console.error('Error al eliminar el ingrediente:', response.data);

--- a/src/controllers/ListaPreciosController.js
+++ b/src/controllers/ListaPreciosController.js
@@ -5,10 +5,7 @@ const baseUrl = 'http://149.50.131.253/api';
 
 export const fetchListaPrecios = async () => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-        console.log('Token utilizado para obtener ventas:', token);
-        const response = await sendAuthenticatedRequest(`${baseUrl}/lista_precios`);
-        console.log('Lista de precios', response);
+    const response = await sendAuthenticatedRequest(`${baseUrl}/lista_precios`);
     return response;
   } catch (error) {
     console.error('Error al obtener la lista de precios:', error);
@@ -26,12 +23,4 @@ export const fetchPrecioPorIdTorta = async (ID_TORTA) => {
 };
 
 
-const waitUntilTokenIsAvailable = async () => {
-  let token = LoginController.getToken();
-  while (!token) {
-      console.log('Esperando a que se obtenga un token de autenticación...');
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      token = LoginController.getToken();
-  }
-  return token;
-};
+const getToken = () => LoginController.getToken();

--- a/src/controllers/LoginController.js
+++ b/src/controllers/LoginController.js
@@ -2,102 +2,57 @@ import axios from 'axios';
 
 const baseUrl = 'http://149.50.131.253/api';
 let authToken = null;
+const getToken = () => authToken || localStorage.getItem('token');
 
 export const sendAuthenticatedRequest = async (url) => {
-    try {
-        const token = authToken;
-        
-        if (!token) {
-            console.error('Error en sendAuthenticatedRequest: No hay token almacenado');
-            throw new Error('No se ha obtenido un token de autenticación');
-        }
-
-        console.log('Enviando petición autenticada a:', url);
-        console.log('Token being sent:', token);
-
-        const response = await axios.get(url, {
-            headers: {
-                'Authorization': `Bearer ${token}`
-            }
-        });
-
-        console.log('Respuesta recibida:', response.status, response.data);
-        return response.data;
-    } catch (error) {
-        console.error('Error en sendAuthenticatedRequest:', {
-            message: error.message,
-            response: error.response ? {
-                status: error.response.status,
-                data: error.response.data
-            } : 'No response'
-        });
-        throw error;
+  try {
+    const token = getToken();
+    if (!token) {
+      throw new Error('No se ha obtenido un token de autenticación');
     }
-}
+    const response = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error en sendAuthenticatedRequest:', error);
+    throw error;
+  }
+};
 
 const storeToken = (token) => {
-    authToken = token;
-    console.log('Token almacenado en storeToken:', authToken);
+  authToken = token;
 };
 
 export const LoginController = {
     loginUser: async (email, contrasena) => {
         try {
-            console.log('Iniciando loginUser con:', { email, contrasena: contrasena ? '*****' : 'undefined' });
-            console.log('URL de login:', `${baseUrl}/login`);
-            
-            const response = await axios.post(`${baseUrl}/login`, { email, contrasena })
-                .catch(error => {
-                    console.error('Error en axios.post:', {
-                        message: error.message,
-                        response: error.response ? {
-                            status: error.response.status,
-                            data: error.response.data
-                        } : 'No response'
-                    });
-                    throw error;
-                });
+            const response = await axios.post(`${baseUrl}/login`, { email, contrasena });
 
-            console.log('Respuesta completa del servidor:', response);
-            
             if (!response.data.token) {
-                console.error('El servidor no devolvió un token en la respuesta:', response.data);
                 throw new Error('No se recibió token en la respuesta');
             }
 
             const token = response.data.token;
             storeToken(token);
-            console.log('Login exitoso, token obtenido:', token);
             return token;
         } catch (error) {
-            console.error('Error en loginUser:', {
-                message: error.message,
-                stack: error.stack,
-                response: error.response ? error.response.data : 'No response data'
-            });
+            console.error('Error en loginUser:', error);
             throw new Error('Credenciales inválidas');
         }
     },
 
-    getToken: () => {
-        const token = authToken;
-        console.log('Obteniendo token actual:', token);
-        return token;
-    },
+    getToken: () => getToken(),
 
     afterLogin: async (email, contrasena, action) => {
         try {
-            console.log('Iniciando afterLogin con:', { email });
-            const token = await LoginController.loginUser(email, contrasena);
-            console.log('Token obtenido en afterLogin:', token);
+            await LoginController.loginUser(email, contrasena);
             const result = await action();
-            console.log('Action completada en afterLogin');
             return result;
         } catch (error) {
-            console.error('Error en afterLogin:', {
-                message: error.message,
-                stack: error.stack
-            });
+            console.error('Error en afterLogin:', error);
             throw error;
         }
     }

--- a/src/controllers/RecetaController.js
+++ b/src/controllers/RecetaController.js
@@ -3,22 +3,12 @@ import { LoginController, sendAuthenticatedRequest } from './LoginController';
 
 const baseUrl = 'http://149.50.131.253/api';
 
-const waitUntilTokenIsAvailable = async () => {
-  let token = LoginController.getToken();
-  while (!token) {
-    console.log('Esperando a que se obtenga un token de autenticación...');
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    token = LoginController.getToken();
-  }
-  return token;
-};
+const getToken = () => LoginController.getToken();
 
 // Función para obtener todas las recetas
 export const fetchRecetas = async () => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    const response = await sendAuthenticatedRequest(`${baseUrl}/recetas`, token);
-    console.log('Respuesta completa de la API:', response);
+    const response = await sendAuthenticatedRequest(`${baseUrl}/recetas`);
 
     if (Array.isArray(response)) {
       return response;
@@ -35,11 +25,10 @@ export const fetchRecetas = async () => {
 // Función para obtener una receta por ID
 export const fetchRecetasById = async (ID_TORTA) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
+    const token = getToken();
     const response = await axios.get(`${baseUrl}/recetas/${ID_TORTA}`, {
-      headers: { 'Authorization': `Bearer ${token}` }
+      headers: { Authorization: `Bearer ${token}` },
     });
-    console.log('Receta por ID:', response.data);
     return response.data;
   } catch (error) {
     console.error('Error al obtener la receta por ID:', error);
@@ -50,11 +39,10 @@ export const fetchRecetasById = async (ID_TORTA) => {
 // Función para agregar una nueva receta
 export const agregarReceta = async (receta) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
+    const token = getToken();
     const response = await axios.post(`${baseUrl}/recetas`, receta, {
-      headers: { 'Authorization': `Bearer ${token}` }
+      headers: { Authorization: `Bearer ${token}` },
     });
-    console.log('Receta agregada:', response.data);
     return response.data;
   } catch (error) {
     console.error('Error al agregar la receta:', error);
@@ -65,16 +53,13 @@ export const agregarReceta = async (receta) => {
 // Función para agregar un nuevo ingrediente a una receta
 export const agregarIngrediente = async (ID_TORTA, ID_INGREDIENTE, cantidad) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    const response = await axios.post(`${baseUrl}/recetas/nueva-relacion`, {
-      ID_TORTA,
-      ID_INGREDIENTE,
-      cantidad,
-    }, {
-      headers: { 'Authorization': `Bearer ${token}` }
-    });
+    const token = getToken();
+    const response = await axios.post(
+      `${baseUrl}/recetas/nueva-relacion`,
+      { ID_TORTA, ID_INGREDIENTE, cantidad },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
 
-    console.log('Respuesta al agregar ingrediente:', response.data);
     if (response.data && response.data.message === 'Nueva relación agregada exitosamente') {
       return { success: true, message: response.data.message };
     } else {
@@ -90,14 +75,13 @@ export const agregarIngrediente = async (ID_TORTA, ID_INGREDIENTE, cantidad) => 
 // Función para eliminar un ingrediente de una receta
 export const eliminarIngrediente = async (ID_TORTA, ID_INGREDIENTE) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    const response = await axios.delete(`${baseUrl}/recetas/${ID_TORTA}/${ID_INGREDIENTE}`, {
-      headers: { 'Authorization': `Bearer ${token}` }
-    });
-    console.log('Respuesta del servidor al eliminar ingrediente:', response);
+    const token = getToken();
+    const response = await axios.delete(
+      `${baseUrl}/recetas/${ID_TORTA}/${ID_INGREDIENTE}`,
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
 
     if (response.status === 200) {
-      console.log('Ingrediente eliminado exitosamente');
       return { success: true, message: 'Ingrediente eliminado exitosamente' };
     } else {
       console.error('Error al eliminar el ingrediente');
@@ -119,14 +103,12 @@ export const editarReceta = async (receta) => {
       throw new Error('Faltan datos de la receta');
     }
 
-    console.log('Datos de la receta a enviar al servidor:', receta);
-
-    const token = await waitUntilTokenIsAvailable();
-    const response = await axios.put(`${baseUrl}/recetas/${ID_TORTA}/${ID_INGREDIENTE}`, { total_cantidad }, {
-      headers: { 'Authorization': `Bearer ${token}` }
-    });
-
-    console.log('Respuesta de la edición de receta:', response.data);
+    const token = getToken();
+    const response = await axios.put(
+      `${baseUrl}/recetas/${ID_TORTA}/${ID_INGREDIENTE}`,
+      { total_cantidad },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
     return response.data;
   } catch (error) {
     console.error('Error al editar la receta:', error);
@@ -138,13 +120,12 @@ export const editarReceta = async (receta) => {
 // Función para borrar una receta
 export const borrarReceta = async (id) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
+    const token = getToken();
     const response = await axios.delete(`${baseUrl}/recetas/${id}`, {
-      headers: { 'Authorization': `Bearer ${token}` }
+      headers: { Authorization: `Bearer ${token}` },
     });
 
     if (response.status === 204) {
-      console.log('Receta eliminada exitosamente');
       return { success: true };
     } else {
       console.error('Error al eliminar la receta');

--- a/src/controllers/TortaController.js
+++ b/src/controllers/TortaController.js
@@ -1,25 +1,15 @@
 import axios from 'axios';
-import {  sendAuthenticatedRequest } from './LoginController';
+import { sendAuthenticatedRequest } from './LoginController';
 import LoginController from './LoginController';
 
 const baseUrl = 'http://149.50.131.253/api';
 
-const waitUntilTokenIsAvailable = async () => {
-  let token = LoginController.getToken();
-  while (!token) {
-      console.log('Esperando a que se obtenga un token de autenticación...');
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      token = LoginController.getToken();
-  }
-  return token;
-};
+const getToken = () => LoginController.getToken();
 
 
 export const fetchTortas = async () => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    const response = await sendAuthenticatedRequest(`${baseUrl}/tortas`, token);
- 
+    const response = await sendAuthenticatedRequest(`${baseUrl}/tortas`);
     return response; // Retorna la respuesta completa
   } catch (error) {
     console.error('Error al obtener las tortas:', error.message);
@@ -30,16 +20,13 @@ export const fetchTortas = async () => {
 
 export const agregarIngrediente = async (ingrediente) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    console.log('Token utilizado para agregar el ingrediente:', token); // Agregar este console log
-    console.log('Datos del ingrediente a agregar:', ingrediente); // Agregar este console log
+    const token = getToken();
     const response = await axios.post(`${baseUrl}/ingredientes`, ingrediente, {
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
-      }
+        Authorization: `Bearer ${token}`,
+      },
     });
-    console.log('Respuesta del servidor al agregar ingrediente:', response); // Agregar este console log
     return response.data;
   } catch (error) {
     console.error('Error al agregar el ingrediente:', error);
@@ -49,28 +36,20 @@ export const agregarIngrediente = async (ingrediente) => {
 
 export const agregarTorta = async (torta) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    console.log('Token utilizado para agregar la torta:', token);
-    console.log('Datos de la torta a agregar:', torta); // Agregamos este console log
+    const token = getToken();
 
     const formData = new FormData();
     formData.append('nombre_torta', torta.nombre_torta);
     formData.append('descripcion_torta', torta.descripcion_torta);
     formData.append('imagen', torta.imagen);  // La imagen debe ser un objeto File
 
-    // Imprime el contenido del FormData para depuración
-    formData.forEach((value, key) => {
-      console.log(`${key}: ${value}`);
-    });
 
     const response = await axios.post(`${baseUrl}/tortas`, formData, {
       headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data',  // Importante para manejar archivos
-      }
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'multipart/form-data',
+      },
     });
-
-    console.log('Respuesta del servidor al agregar la torta:', response);
     return response.data;
   } catch (error) {
     console.error('Error al agregar la torta:', error);
@@ -83,9 +62,7 @@ export const agregarTorta = async (torta) => {
 
 export const editarTorta = async (torta) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    console.log('Token utilizado para editar la torta:', token);
-    console.log('Datos del torta a editar:', torta);
+    const token = getToken();
 
     const formData = new FormData();
     formData.append('nombre_torta', torta.nombre_torta);
@@ -98,12 +75,10 @@ export const editarTorta = async (torta) => {
 
     const response = await axios.put(`${baseUrl}/tortas/${torta.ID_TORTA}`, formData, {
       headers: {
-        'Authorization': `Bearer ${token}`,
+        Authorization: `Bearer ${token}`,
         'Content-Type': 'multipart/form-data',
-      }
+      },
     });
-
-    console.log('Respuesta del servidor al editar torta:', response);
     return response.data;
   } catch (error) {
     console.error('Error al editar la torta:', error);
@@ -114,17 +89,14 @@ export const editarTorta = async (torta) => {
 
 export const borrarTorta = async (id) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    console.log('Token utilizado para borrar la torta:', token); // Agregar este console log
-    console.log('ID de la torta a borrar:', id); // Agregar este console log
+    const token = getToken();
     const response = await axios.delete(`${baseUrl}/tortas/${id}`, {
       headers: {
-        'Authorization': `Bearer ${token}`,
-      }
+        Authorization: `Bearer ${token}`,
+      },
     });
 
     if (response.status === 200) {
-      console.log('Torta eliminada exitosamente');
       return { success: true };
     } else {
       console.error('Error al eliminar la torta:', response.data);

--- a/src/controllers/VentaController.js
+++ b/src/controllers/VentaController.js
@@ -5,10 +5,7 @@ const baseUrl = 'http://149.50.131.253/api';
 
 export const obtenerVentas = async () => {
     try {
-        const token = await waitUntilTokenIsAvailable();
-       
         const ventas = await sendAuthenticatedRequest(`${baseUrl}/ventas`);
-       
         return ventas;
     } catch (error) {
         console.error('Error al obtener las ventas:', error.message);
@@ -18,18 +15,12 @@ export const obtenerVentas = async () => {
 
 export const registrarVenta = async (idTorta, id_usuario) => {
   try {
-    const token = await waitUntilTokenIsAvailable();
-    console.log('Token utilizado para registrar la venta:', token); // Agregar este console log
-    console.log('ID de la torta a vender:', idTorta); // Agregar este console log
-    const response = await axios.post(`${baseUrl}/ventas`, {
-      id_torta: idTorta,
-      id_usuario: id_usuario // Incluye el ID del usuario en los datos enviados al servidor
-    }, {
-      headers: {
-        'Authorization': `Bearer ${token}`
-      }
-    });
-    console.log('Respuesta del servidor al registrar venta:', response); // Agregar este console log
+    const token = LoginController.getToken();
+    const response = await axios.post(
+      `${baseUrl}/ventas`,
+      { id_torta: idTorta, id_usuario },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
     return response.data;
   } catch (error) {
     if (error.response && error.response.data) {
@@ -46,11 +37,7 @@ export const registrarVenta = async (idTorta, id_usuario) => {
 
 export const obtenerCantidadVentas = async () => {
   try {
-      const token = await waitUntilTokenIsAvailable(); // Esperar hasta que el token esté disponible
-
-      
       const response = await sendAuthenticatedRequest(`${baseUrl}/ventas/cantidad`);
-     
       return response;
   } catch (error) {
       console.error('Error al obtener la cantidad de ventas:', error);
@@ -60,10 +47,7 @@ export const obtenerCantidadVentas = async () => {
 
 export const obtenerCantidadVentasSemanales = async () => {
   try {
-      const token = await waitUntilTokenIsAvailable();
-    
       const response = await sendAuthenticatedRequest(`${baseUrl}/ventas/cantidad-semana`);
-      console.log('Respuesta del servidor cuando obtengo las ventas semanales:', response); // Agregar este console log
       return response;
   } catch (error) {
       console.error('Error al obtener la cantidad de ventas semanales:', error);
@@ -73,10 +57,7 @@ export const obtenerCantidadVentasSemanales = async () => {
 
 export const obtenerPorcentajeVentas = async () => {
   try {
-      const token = await waitUntilTokenIsAvailable();
-   
       const response = await sendAuthenticatedRequest(`${baseUrl}/ventas/porcentaje-ventas`);
-      console.log('Respuesta del servidor cuando obtengo las ventas semanales:', response); // Agregar este console log
       return response;
   } catch (error) {
       console.error('Error al obtener el porcentaje de ventas:', error);
@@ -86,10 +67,7 @@ export const obtenerPorcentajeVentas = async () => {
 
 export const obtenerGanancias = async () => {
   try {
-      const token = await waitUntilTokenIsAvailable(); // Esperar hasta que el token esté disponible
-      
       const response = await sendAuthenticatedRequest(`${baseUrl}/ventas/ganancias`);
-      
       return response;
   } catch (error) {
       console.error('Error al obtener ganancias:', error);
@@ -97,21 +75,3 @@ export const obtenerGanancias = async () => {
   }
 };
 
-const waitUntilTokenIsAvailable = async () => {
-    let token = LoginController.getToken();
-    while (!token) {
-        console.log('Esperando a que se obtenga un token de autenticación...');
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        token = LoginController.getToken();
-    }
-    return token;
-};
-
-const handleTokenExpiration = () => {
-    console.error('El token de autenticación ha expirado o es inválido');
-};
-
-const handleGeneralError = (error) => {
-    console.error('Ocurrió un error:', error.message);
-    throw error;
-};

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,17 +1,33 @@
+let cachedToken = null;
+let cachedExpiration = null;
+
 export function isTokenValid(token) {
   if (!token) return false;
+
+  if (token === cachedToken && cachedExpiration !== null) {
+    return cachedExpiration > Date.now();
+  }
+
   try {
     const payloadBase64 = token.split('.')[1];
     if (!payloadBase64) return false;
     const decodedPayload = JSON.parse(atob(payloadBase64));
+    cachedToken = token;
+    cachedExpiration = decodedPayload.exp ? decodedPayload.exp * 1000 : null;
+
     if (!decodedPayload.exp) return true;
-    return decodedPayload.exp * 1000 > Date.now();
+    return cachedExpiration > Date.now();
   } catch (e) {
     console.error('Invalid token', e);
+    cachedToken = null;
+    cachedExpiration = null;
     return false;
   }
 }
 
 export function logout() {
   localStorage.removeItem('token');
+  cachedToken = null;
+  cachedExpiration = null;
 }
+


### PR DESCRIPTION
## Summary
- add token validation cache
- reduce logging and polling for token in controllers
- use stored token directly for API calls

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c87b07380832b998c6904f176ad83